### PR TITLE
Removing Animations from Player Entites

### DIFF
--- a/src/main/java/de/gerrygames/mainhandsynchronization/mixin/ToggleAnimations.java
+++ b/src/main/java/de/gerrygames/mainhandsynchronization/mixin/ToggleAnimations.java
@@ -1,0 +1,18 @@
+package de.gerrygames.mainhandsynchronization.mixin;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public class ToggleAnimations {
+    @Inject(method="updateWalkAnimation", at = @At("HEAD"), cancellable = true)
+    private void injected(float f, CallbackInfo ci) {
+        if (((LivingEntity) (Object) this) instanceof Player) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mainhandsynchronization.mixins.json
+++ b/src/main/resources/mainhandsynchronization.mixins.json
@@ -3,7 +3,8 @@
 	"package": "de.gerrygames.mainhandsynchronization.mixin",
 	"compatibilityLevel": "JAVA_17",
 	"mixins": [
-		"PlayerMixin"
+		"PlayerMixin",
+		"ToggleAnimations"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
## Why should this be added?

This pull request disables the animation of player entities. This enhances the game experience for competitive, i.e., "sweaty," PvP players who often seek ways to optimize their gaming experience. For passionate PvP enthusiasts, responsiveness and clarity in combat are crucial elements that contribute to their competitive edge.

This change aligns with one of the core principles on which the mod was developed over many years. Therefore, in my opinion, this pull request would contribute significantly to the overall quality of this mod. Furthermore, it aligns with the design philosophy of the mod, as the animation being disabled becomes a permanent feature once the mod is installed. This continues the trend set by the first addition to the mod, where the main hand of all players is standardized. That feature is also fixed and cannot be toggled once the mod is installed.